### PR TITLE
James timezone updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Build
 build/
+james_script.sh
+james_py.py
+*.rpm

--- a/databridge_etl_tools/carto_.py
+++ b/databridge_etl_tools/carto_.py
@@ -133,7 +133,7 @@ class Carto():
 
             if candidate_shape:
                 # Create a new df that drops rows with a null shape
-                non_null_df = df.dropna(subset='shape', how='any')
+                non_null_df = df.dropna(subset=['shape'], how='any')
 
                 # If we still have data..
                 if not non_null_df.empty:
@@ -359,9 +359,9 @@ class Carto():
         if num_rows_in_table != num_rows_expected:
             self.logger.error('Did not insert all rows, reverting...')
             stmt = 'BEGIN;' + \
-                    'DROP TABLE if exists "{}" cascade;'.format(temp_table_name) + \
+                    'DROP TABLE if exists "{}" cascade;'.format(self.temp_table_name) + \
                     'COMMIT;'
-            execute_sql(stmt)
+            self.execute_sql(stmt)
             exit(1)
         self.logger.info('Row count verified.\n')
 

--- a/databridge_etl_tools/carto_.py
+++ b/databridge_etl_tools/carto_.py
@@ -41,7 +41,7 @@ class Carto():
                  s3_key,
                  **kwargs):
         self.connection_string = connection_string
-        self.table_name = table_name
+        self.table_name = table_name.lower()
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
         self.select_users = kwargs.get('select_users', None)
@@ -199,7 +199,7 @@ class Carto():
                         atype = 'float4'
                     elif v == np.object:
                         # if object, check if it's a datetime
-                        non_null_df = df.dropna(subset=k, how='any')
+                        non_null_df = df.dropna(subset=[k], how='any')
                         #print(f'DEBUG: {k}')
                         ex_val = non_null_df.loc[1][k]
                         if isinstance(ex_val, str):
@@ -224,7 +224,7 @@ class Carto():
                         # Also determine varchar length
                         if atype is None:
                             # Drop all null values for this column
-                            non_null_df = df.dropna(subset=k, how='any')
+                            non_null_df = df.dropna(subset=[k], how='any')
                             max_len = non_null_df[k].str.len().max()
                             #atype = f'varchar({max_len+50})'
                             # nvm just do text which has no length

--- a/databridge_etl_tools/oracle.py
+++ b/databridge_etl_tools/oracle.py
@@ -114,8 +114,9 @@ class Oracle():
         for field in data.fieldnames(): 
             if 'datetime' in etl.typeset(data, field): 
                 datetime_fields.append(field)
-        print(f'Converting {datetime_fields} fields to Eastern timezone datetime')
-        data = etl.convert(data, datetime_fields, pytz.timezone('US/Eastern').localize)
+        if datetime_fields:
+            print(f'Converting {datetime_fields} fields to Eastern timezone datetime')
+            data = etl.convert(data, datetime_fields, pytz.timezone('US/Eastern').localize)
         
         try:
             etl.tocsv(data, self.csv_path, encoding='utf-8')

--- a/databridge_etl_tools/oracle.py
+++ b/databridge_etl_tools/oracle.py
@@ -101,28 +101,27 @@ class Oracle():
         '''
         Extract data from database and save as a CSV file. Any fields that contain 
         datetime information will be converted to US/Eastern time zone (with historical 
-        accuracy for Daylight Savings Time). However, fields that are type 'date' 
-        (note 'datetime') will also become datetimes with US/Eastern time zone information. 
+        accuracy for Daylight Savings Time). Oracle also stories DATE fields with a 
+        time component as well, so "DATE" fields that may appear without time information
+        will also have timezone niformation added.
         Append CSV file to S3 bucket.
         '''
         self.logger.info('Starting extract from {}'.format(self.schema_table_name))
         import geopetl
 
+        data = etl.fromoraclesde(self.conn, self.schema_table_name, geom_with_srid=True)
+        datetime_fields = []
+        for field in data.fieldnames(): 
+            if 'datetime' in etl.typeset(data, field): 
+                datetime_fields.append(field)
+        print(f'Converting {datetime_fields} fields to Eastern timezone datetime')
+        data = etl.convert(data, datetime_fields, pytz.timezone('US/Eastern').localize)
+        
         try:
-            # Date columns become datetimes columns because of cx_oracle and petl 
-            # To avoid that, one might want to convert first to Pandas
-            data = etl.fromoraclesde(self.conn, self.schema_table_name, geom_with_srid=True)
-            datetime_fields = []
-            for field in data.fieldnames(): 
-                if 'datetime' in etl.typeset(data, field): 
-                    datetime_fields.append(field)
-            print(f'Converting {datetime_fields} fields to Eastern timezone datetime')
-            etl.convert(data, datetime_fields, pytz.timezone('US/Eastern').localize) \
-                .tocsv(self.csv_path, encoding='utf-8')
+            etl.tocsv(data, self.csv_path, encoding='utf-8')
         except UnicodeError:
             self.logger.info("Exception encountered trying to extract to CSV with utf-8 encoding, trying latin-1...")
-            etl.fromoraclesde(self.conn, self.schema_table_name, geom_with_srid=True) \
-               .tocsv(self.csv_path, encoding='latin-1')
+            etl.tocsv(data, self.csv_path, encoding='latin-1')
 
         # Confirm CSV isn't empty
         try:


### PR DESCRIPTION
File changes: 

* `carto_.py`: I had to make these changes to use `databridge-etl-tools` as a package but the script worked without the changes when I ran things with the docker container, which I don't understand
* `oracle.py` contains the changes to add timezone information to all datetime fields in Oracle. Recall as Alex said that Oracle stores dates actually as datetimes, so some custom logic would be needed in the extract to prevent values that we actually want as dates to not receive timezone information