### PR TITLE
Exclude M and Z values in shape when extracting from Oracle, and make S3 upload optional

### DIFF
--- a/databridge_etl_tools/oracle/oracle_commands.py
+++ b/databridge_etl_tools/oracle/oracle_commands.py
@@ -7,8 +7,8 @@ import click
 @click.option('--table_name', required=True)
 @click.option('--table_schema', required=True)
 @click.option('--connection_string', required=True)
-@click.option('--s3_bucket', required=True)
-@click.option('--s3_key', required=True)
+@click.option('--s3_bucket', required=False)
+@click.option('--s3_key', required=False)
 def oracle(ctx, **kwargs):
     '''Run ETL commands for Oracle'''
     ctx.obj = Oracle(**kwargs)

--- a/databridge_etl_tools/postgres/postgres.py
+++ b/databridge_etl_tools/postgres/postgres.py
@@ -1,4 +1,4 @@
-import csv, sys, re, ast
+import csv, os, sys, re, ast
 import psycopg2.sql as sql
 import geopetl
 import pytz
@@ -362,7 +362,15 @@ class Postgres():
         assert db_newest_row_count == num_rows_in_csv
 
         self.check_remove_nulls()
-        self.load_csv_to_s3(path=self.csv_path)
+
+        if self.s3_bucket and self.s3_key:
+            self.load_csv_to_s3(path=self.csv_path)
+        else:
+            self.logger.info('Saving CSV to local working directory.')
+            # Move CSV out of temp path in self.csv_path and place in the current working directory
+            os.replace(self.csv_path, os.path.join(os.getcwd(), self.table_name + '.csv'))
+            
+        
     
     def create_temp_table(self): 
         '''Create an empty temp table from self.table_name in the same schema'''

--- a/databridge_etl_tools/postgres/postgres_commands.py
+++ b/databridge_etl_tools/postgres/postgres_commands.py
@@ -11,8 +11,8 @@ import click
 @click.option('--connection_string', required=True)
 @click.option('--table_name', required=True)
 @click.option('--table_schema', required=True)
-@click.option('--s3_bucket')
-@click.option('--s3_key')
+@click.option('--s3_bucket', required=False)
+@click.option('--s3_key', required=False)
 def postgres(ctx, **kwargs):
     '''Run ETL commands for Postgres'''
     ctx.obj = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ py_modules = ['databridge_etl_tools']
 
 [project]
 name = "databridge-etl-tools"
-version = "1.2.3"
+version = "1.3.0"
 description = "Command line tools to extract and load SQL data to various endpoints"
 authors = [
     {name = "citygeo", email = "maps@phila.gov"},


### PR DESCRIPTION
Use a fancy function to modify petl after extracted to remove M or Z values.

Additionally, make S3 uploads optional. If not --s3_key and --s3_bucket are not specified, the CSV will be saved to the working directory.