### PR TITLE
Optimize Airflow Docker Image

### DIFF
--- a/Dockerfile-airflow
+++ b/Dockerfile-airflow
@@ -30,10 +30,6 @@ COPY --chown=airflow:airflow tests/ ./tests/
 # Python syntax check
 RUN python -m compileall ./databridge_etl_tools
 
-# Dedicated sandbox for Openmetadata library
-RUN python -m venv /home/airflow/venvs/om && \
-    /home/airflow/venvs/om/bin/pip install "openmetadata-ingestion==1.13.0" "cachetools" "pendulum"
-
 # Dedicated sandbox for ArcGIS library
 RUN python -m venv /home/airflow/venvs/arcgis && \
     /home/airflow/venvs/arcgis/bin/pip install "pendulum" "arcgis"

--- a/Dockerfile-airflow
+++ b/Dockerfile-airflow
@@ -4,18 +4,18 @@ USER root
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
-    libpq-dev \
+    # libpq-dev \
     libpq5 \
-    apt-utils \
+    # apt-utils \
     build-essential \
-    ca-certificates \
+    # ca-certificates \
     curl \
     git \
-    gnupg \
-    lsb-release \
+    # gnupg \
+    # lsb-release \
     wget \
-    unzip \
-    libkrb5-dev \
+    # unzip \
+    # libkrb5-dev \
   && apt-get autoremove -yqq --purge \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Airflow Docker Image is very big, 1.5gb+

Summary of optimizations:
* Remove no longer needed OpenMetadata virtual environment